### PR TITLE
Enable poe tests in Codebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 .env
 *.iml
+node_modules

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+cd frontend && npm run prettier-check

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,20 @@
+# RASD Backend
+
+RASD Python AWS Lambda backend REST API using Poetry and Fast API.
+
+## Development
+
+Install dependencies:
+```bash
+poetry install
+```
+
+Run tests:
+```bash
+poe test
+```
+
+Run locally:
+```bash
+poe serve
+```

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -521,7 +521,7 @@ version = "2025.8.3"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["rasd_fastapi"]
+groups = ["dev", "rasd_fastapi"]
 files = [
     {file = "certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5"},
     {file = "certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407"},
@@ -533,7 +533,7 @@ version = "1.17.1"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.8"
-groups = ["rasd_fastapi"]
+groups = ["dev", "rasd_fastapi"]
 markers = "platform_python_implementation != \"PyPy\""
 files = [
     {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
@@ -614,7 +614,7 @@ version = "3.4.3"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
-groups = ["rasd_fastapi"]
+groups = ["dev", "rasd_fastapi"]
 files = [
     {file = "charset_normalizer-3.4.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fb7f67a1bfa6e40b438170ebdc8158b78dc465a5a67b6dde178a46987b244a72"},
     {file = "charset_normalizer-3.4.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc9370a2da1ac13f0153780040f465839e6cccb4a1e44810124b4e22483c93fe"},
@@ -847,7 +847,7 @@ version = "45.0.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.7"
-groups = ["rasd_fastapi"]
+groups = ["dev", "rasd_fastapi"]
 files = [
     {file = "cryptography-45.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3be4f21c6245930688bd9e162829480de027f8bf962ede33d4f8ba7d67a00cee"},
     {file = "cryptography-45.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:67285f8a611b0ebc0857ced2081e30302909f571a46bfa7a3cc0ad303fe015c6"},
@@ -921,6 +921,29 @@ doq = ["aioquic (>=1.0.0)"]
 idna = ["idna (>=3.7)"]
 trio = ["trio (>=0.23)"]
 wmi = ["wmi (>=1.5.1)"]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+description = "A Python library for the Docker Engine API."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0"},
+    {file = "docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c"},
+]
+
+[package.dependencies]
+pywin32 = {version = ">=304", markers = "sys_platform == \"win32\""}
+requests = ">=2.26.0"
+urllib3 = ">=1.26.0"
+
+[package.extras]
+dev = ["coverage (==7.2.7)", "pytest (==7.4.2)", "pytest-cov (==4.1.0)", "pytest-timeout (==2.1.0)", "ruff (==0.1.8)"]
+docs = ["myst-parser (==0.18.0)", "sphinx (==5.1.1)"]
+ssh = ["paramiko (>=2.4.3)"]
+websockets = ["websocket-client (>=1.3.0)"]
 
 [[package]]
 name = "ecdsa"
@@ -1060,7 +1083,7 @@ version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["rasd_fastapi"]
+groups = ["dev", "rasd_fastapi"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -1087,7 +1110,7 @@ version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
-groups = ["rasd_fastapi"]
+groups = ["dev", "rasd_fastapi"]
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -1132,7 +1155,7 @@ version = "3.0.2"
 description = "Safely add untrusted strings to HTML/XML markup."
 optional = false
 python-versions = ">=3.9"
-groups = ["rasd_fastapi"]
+groups = ["dev", "rasd_fastapi"]
 files = [
     {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8"},
     {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158"},
@@ -1196,6 +1219,53 @@ files = [
     {file = "MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a"},
     {file = "markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"},
 ]
+
+[[package]]
+name = "moto"
+version = "4.2.14"
+description = ""
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "moto-4.2.14-py2.py3-none-any.whl", hash = "sha256:6d242dbbabe925bb385ddb6958449e5c827670b13b8e153ed63f91dbdb50372c"},
+    {file = "moto-4.2.14.tar.gz", hash = "sha256:8f9263ca70b646f091edcc93e97cda864a542e6d16ed04066b1370ed217bd190"},
+]
+
+[package.dependencies]
+boto3 = ">=1.9.201"
+botocore = ">=1.12.201"
+cryptography = ">=3.3.1"
+docker = {version = ">=3.0.0", optional = true, markers = "extra == \"dynamodb\""}
+Jinja2 = ">=2.10.1"
+py-partiql-parser = {version = "0.5.0", optional = true, markers = "extra == \"dynamodb\""}
+python-dateutil = ">=2.1,<3.0.0"
+requests = ">=2.5"
+responses = ">=0.13.0"
+werkzeug = ">=0.5,<2.2.0 || >2.2.0,<2.2.1 || >2.2.1"
+xmltodict = "*"
+
+[package.extras]
+all = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "multipart", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.5.0)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+apigateway = ["PyYAML (>=5.1)", "ecdsa (!=0.15)", "openapi-spec-validator (>=0.5.0)", "python-jose[cryptography] (>=3.1.0,<4.0.0)"]
+apigatewayv2 = ["PyYAML (>=5.1)"]
+appsync = ["graphql-core"]
+awslambda = ["docker (>=3.0.0)"]
+batch = ["docker (>=3.0.0)"]
+cloudformation = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.5.0)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+cognitoidp = ["ecdsa (!=0.15)", "python-jose[cryptography] (>=3.1.0,<4.0.0)"]
+dynamodb = ["docker (>=3.0.0)", "py-partiql-parser (==0.5.0)"]
+dynamodbstreams = ["docker (>=3.0.0)", "py-partiql-parser (==0.5.0)"]
+ec2 = ["sshpubkeys (>=3.1.0)"]
+glue = ["pyparsing (>=3.0.7)"]
+iotdata = ["jsondiff (>=1.1.2)"]
+proxy = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=2.5.1)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "multipart", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.5.0)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+resourcegroupstaggingapi = ["PyYAML (>=5.1)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.5.0)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)"]
+s3 = ["PyYAML (>=5.1)", "py-partiql-parser (==0.5.0)"]
+s3crc32c = ["PyYAML (>=5.1)", "crc32c", "py-partiql-parser (==0.5.0)"]
+server = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "flask (!=2.2.0,!=2.2.1)", "flask-cors", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.5.0)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
+ssm = ["PyYAML (>=5.1)"]
+xray = ["aws-xray-sdk (>=0.93,!=0.96)", "setuptools"]
 
 [[package]]
 name = "mypy"
@@ -1377,6 +1447,21 @@ tomli = ">=1.2.2"
 poetry-plugin = ["poetry (>=1.0,<2.0)"]
 
 [[package]]
+name = "py-partiql-parser"
+version = "0.5.0"
+description = "Pure Python PartiQL Parser"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "py-partiql-parser-0.5.0.tar.gz", hash = "sha256:427a662e87d51a0a50150fc8b75c9ebb4a52d49129684856c40c88b8c8e027e4"},
+    {file = "py_partiql_parser-0.5.0-py3-none-any.whl", hash = "sha256:dc454c27526adf62deca5177ea997bf41fac4fd109c5d4c8d81f984de738ba8f"},
+]
+
+[package.extras]
+dev = ["black (==22.6.0)", "flake8", "mypy", "pytest"]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.1"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
@@ -1394,7 +1479,7 @@ version = "2.22"
 description = "C parser in Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["rasd_fastapi"]
+groups = ["dev", "rasd_fastapi"]
 markers = "platform_python_implementation != \"PyPy\""
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
@@ -1580,12 +1665,106 @@ files = [
 dev = ["atomicwrites (==1.2.1)", "attrs (==19.2.0)", "coverage (==6.5.0)", "hatch", "invoke (==1.7.3)", "more-itertools (==4.3.0)", "pbr (==4.3.0)", "pluggy (==1.0.0)", "py (==1.11.0)", "pytest (==7.2.0)", "pytest-cov (==4.0.0)", "pytest-timeout (==2.1.0)", "pyyaml (==5.1)"]
 
 [[package]]
+name = "pywin32"
+version = "311"
+description = "Python for Window Extensions"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3"},
+    {file = "pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b"},
+    {file = "pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b"},
+    {file = "pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151"},
+    {file = "pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503"},
+    {file = "pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2"},
+    {file = "pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31"},
+    {file = "pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067"},
+    {file = "pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852"},
+    {file = "pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d"},
+    {file = "pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d"},
+    {file = "pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a"},
+    {file = "pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee"},
+    {file = "pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87"},
+    {file = "pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42"},
+    {file = "pywin32-311-cp38-cp38-win32.whl", hash = "sha256:6c6f2969607b5023b0d9ce2541f8d2cbb01c4f46bc87456017cf63b73f1e2d8c"},
+    {file = "pywin32-311-cp38-cp38-win_amd64.whl", hash = "sha256:c8015b09fb9a5e188f83b7b04de91ddca4658cee2ae6f3bc483f0b21a77ef6cd"},
+    {file = "pywin32-311-cp39-cp39-win32.whl", hash = "sha256:aba8f82d551a942cb20d4a83413ccbac30790b50efb89a75e4f586ac0bb8056b"},
+    {file = "pywin32-311-cp39-cp39-win_amd64.whl", hash = "sha256:e0c4cfb0621281fe40387df582097fd796e80430597cb9944f0ae70447bacd91"},
+    {file = "pywin32-311-cp39-cp39-win_arm64.whl", hash = "sha256:62ea666235135fee79bb154e695f3ff67370afefd71bd7fea7512fc70ef31e3d"},
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
+    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
+    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
+    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.9"
-groups = ["rasd_fastapi"]
+groups = ["dev", "rasd_fastapi"]
 files = [
     {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
     {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
@@ -1600,6 +1779,26 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "responses"
+version = "0.25.8"
+description = "A utility library for mocking out the `requests` Python library."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "responses-0.25.8-py3-none-any.whl", hash = "sha256:0c710af92def29c8352ceadff0c3fe340ace27cf5af1bbe46fb71275bcd2831c"},
+    {file = "responses-0.25.8.tar.gz", hash = "sha256:9374d047a575c8f781b94454db5cab590b6029505f488d12899ddb10a4af1cf4"},
+]
+
+[package.dependencies]
+pyyaml = "*"
+requests = ">=2.30.0,<3.0"
+urllib3 = ">=1.25.10,<3.0"
+
+[package.extras]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "tomli ; python_version < \"3.11\"", "tomli-w", "types-PyYAML", "types-requests"]
 
 [[package]]
 name = "rfc3986"
@@ -1837,7 +2036,37 @@ h11 = ">=0.8"
 [package.extras]
 standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.13)", "websockets (>=10.4)"]
 
+[[package]]
+name = "werkzeug"
+version = "3.1.3"
+description = "The comprehensive WSGI web application library."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e"},
+    {file = "werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746"},
+]
+
+[package.dependencies]
+MarkupSafe = ">=2.1.1"
+
+[package.extras]
+watchdog = ["watchdog (>=2.3)"]
+
+[[package]]
+name = "xmltodict"
+version = "0.15.0"
+description = "Makes working with XML feel like you are working with JSON"
+optional = false
+python-versions = ">=3.6"
+groups = ["dev"]
+files = [
+    {file = "xmltodict-0.15.0-py2.py3-none-any.whl", hash = "sha256:8887783bf1faba1754fc45fdf3fe03fbb3629c811ae57f91c018aace4c58d4ed"},
+    {file = "xmltodict-0.15.0.tar.gz", hash = "sha256:c6d46b4e3413d1e4fc3e5016f0f1c7a5c10f8ce39efaa0cb099af986ecfc9a53"},
+]
+
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.13"
-content-hash = "1c7f516cf196b79bb931adc5e38d7f894acbc483eb795b4750d16e58b880f398"
+content-hash = "c948eeb0779a417f7fd3380fa9a6e0deb58834b94b27b13b5397e4eceaeae63f"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,6 +30,7 @@ pytest-cov = "^4.0.0"
 covdefaults = "^2.2.2"
 boto3 = "^1.26.76"
 boto3-stubs = {extras = ["dynamodb", "cognito-idp", "sesv2"], version = "^1.26.76"}
+moto = {extras = ["dynamodb"], version = "^4.2.0"}
 
 [tool.poe.tasks]
 serve = "uvicorn lambdas.rasd_fastapi.main:app --reload"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -34,7 +34,7 @@ moto = {extras = ["dynamodb"], version = "^4.2.0"}
 
 [tool.poe.tasks]
 serve = "uvicorn lambdas.rasd_fastapi.main:app --reload"
-test = "pytest tests --cov=lambdas"
+test = "pytest tests --cov=lambdas --cov-fail-under=30"
 type = "mypy tests lambdas"
 lint = "ruff check tests lambdas"
 clean = "rm -rf **/.ruff_cache **/.coverage **/.mypy_cache **/.pytest_cache **/__pycache__"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,13 +4,36 @@
 # Standard
 import json
 import pathlib
+import os
+from unittest.mock import Mock, patch
 
 # Third-Party
 import fastapi.encoders
 import pydantic
+import pytest
+import boto3
+from moto import mock_dynamodb
 
 # Typing
 from typing import Dict, Any, Union
+
+
+# Set environment variables before any imports
+os.environ.update({
+    "AWS_ACCESS_KEY_ID": "test-key",
+    "AWS_SECRET_ACCESS_KEY": "test-secret",
+    "AWS_DEFAULT_REGION": "ap-southeast-2",
+    "AWS_COGNITO_POOL_ID": "test-pool",
+    "AWS_COGNITO_CLIENT_ID": "test-client",
+    "AWS_COGNITO_CLIENT_SECRET_KEY": "test-secret",
+    "ABN_LOOKUP_GUID": "test-guid-123"
+})
+
+# Mock boto3 client at module level to prevent AWS calls during settings import
+with patch("boto3.client") as mock_client:
+    mock_sm = Mock()
+    mock_sm.get_secret_value.side_effect = Exception("No secrets in test")
+    mock_client.return_value = mock_sm
 
 
 # Shortcuts
@@ -51,3 +74,118 @@ def matches(a: DictOrModel, b: DictOrModel) -> bool:
 
     # Check and Return
     return all(x in b_items for x in a_items)
+
+
+@pytest.fixture
+def mock_dynamodb_tables():
+    """Create mock DynamoDB tables for testing."""
+    with mock_dynamodb():
+        # Create DynamoDB resource
+        dynamodb = boto3.resource("dynamodb", region_name="ap-southeast-2")
+        
+        # Create test tables
+        tables = [
+            "Metadata",
+            "Organisations", 
+            "Registrations",
+            "DataAccessRequests"
+        ]
+        
+        for table_name in tables:
+            dynamodb.create_table(
+                TableName=table_name,
+                KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+                AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+                BillingMode="PAY_PER_REQUEST"
+            )
+        
+        yield dynamodb
+
+
+@pytest.fixture
+def mock_abn_responses():
+    """Mock ABN lookup service responses."""
+    responses = {
+        "94119508824": {
+            "Abn": "94119508824",
+            "AbnStatus": "Active",
+            "AbnStatusEffectiveFrom": "2000-01-01",
+            "Acn": "119508824",
+            "AddressPostcode": "6000",
+            "AddressState": "WA",
+            "BusinessName": [],
+            "EntityName": "TEKNO PTY LTD",
+            "EntityTypeCode": "PRV",
+            "EntityTypeName": "Australian Private Company",
+            "Message": ""
+        },
+        "50110219460": {
+            "Abn": "50110219460",
+            "AbnStatus": "Active",
+            "AbnStatusEffectiveFrom": "2000-01-01",
+            "Acn": "110219460",
+            "AddressPostcode": "2000",
+            "AddressState": "NSW",
+            "BusinessName": [],
+            "EntityName": "EXAMPLE PTY LTD",
+            "EntityTypeCode": "PRV",
+            "EntityTypeName": "Australian Private Company",
+            "Message": ""
+        },
+        "51824753556": {
+            "Abn": "51824753556",
+            "AbnStatus": "Active",
+            "AbnStatusEffectiveFrom": "2000-01-01",
+            "Acn": "824753556",
+            "AddressPostcode": "2600",
+            "AddressState": "ACT",
+            "BusinessName": [],
+            "EntityName": "AUSTRALIAN TAXATION OFFICE",
+            "EntityTypeCode": "GOV",
+            "EntityTypeName": "Government Entity",
+            "Message": ""
+        },
+        "62276640408": {
+            "Abn": "62276640408",
+            "AbnStatus": "Active",
+            "AbnStatusEffectiveFrom": "2000-01-01",
+            "Acn": "276640408",
+            "AddressPostcode": "6000",
+            "AddressState": "WA",
+            "BusinessName": [],
+            "EntityName": "AQUINO, TANYA NICOLE",
+            "EntityTypeCode": "IND",
+            "EntityTypeName": "Individual/Sole Trader",
+            "Message": ""
+        }
+    }
+    
+    def mock_get(url, **kwargs):
+        # Extract ABN from params
+        params = kwargs.get('params', {})
+        abn_param = params.get('abn', '')
+        
+        # Clean ABN (remove spaces and convert to string)
+        abn = str(abn_param).replace(" ", "").replace("+", "")
+        
+        response_data = responses.get(abn, {
+            "Abn": "",
+            "AbnStatus": "Cancelled",
+            "AbnStatusEffectiveFrom": "2000-01-01",
+            "Acn": "",
+            "AddressPostcode": "",
+            "AddressState": "",
+            "BusinessName": [],
+            "EntityName": "",
+            "EntityTypeCode": "",
+            "EntityTypeName": "",
+            "Message": "ABN not found"
+        })
+        
+        mock_response = Mock()
+        mock_response.text = f"rasd({json.dumps(response_data)})"
+        mock_response.status_code = 200
+        return mock_response
+    
+    with patch("httpx.get", side_effect=mock_get):
+        yield

--- a/backend/tests/rasd_fastapi/crud/test_metadata.py
+++ b/backend/tests/rasd_fastapi/crud/test_metadata.py
@@ -9,7 +9,7 @@ from rasd_fastapi.schemas import metadata as metadata_schemas
 from tests import conftest
 
 
-def test_metadata_crud() -> None:
+def test_metadata_crud(mock_dynamodb_tables) -> None:
     """Tests the Meatadata CRUD abstraction."""
     # Create Database Session
     db_session = session.db_session()

--- a/backend/tests/rasd_fastapi/crud/test_organisations.py
+++ b/backend/tests/rasd_fastapi/crud/test_organisations.py
@@ -8,7 +8,7 @@ from rasd_fastapi.schemas import organisations as org_schemas
 from tests import conftest
 
 
-def test_organisations_crud() -> None:
+def test_organisations_crud(mock_dynamodb_tables, mock_abn_responses) -> None:
     """Tests the Organisation CRUD abstraction."""
     # Create Database Session
     db_session = session.db_session()

--- a/backend/tests/rasd_fastapi/services/test_abn.py
+++ b/backend/tests/rasd_fastapi/services/test_abn.py
@@ -28,7 +28,7 @@ from rasd_fastapi.services import abn
         ("94 119 508 824", "FAKE NAME", False),  # Registered, wrong entity name
     ]
 )
-def test_verify_abn(value: str, name: str, valid: bool) -> None:
+def test_verify_abn(mock_abn_responses, value: str, name: str, valid: bool) -> None:
     """Tests the ABN field validation.
 
     Args:

--- a/cicd/rasd-service/app/rasd_service.yaml
+++ b/cicd/rasd-service/app/rasd_service.yaml
@@ -767,18 +767,18 @@ Resources:
           Value: !Ref AWS::StackName
 
 Outputs:
-  # CognitoPoolId:
-  #   Description: The Cognito Pool ID
-  #   Value: !Ref CognitoPool
-  # CognitoClientId:
-  #   Description: The Cognito Client ID
-  #   Value: !Ref CognitoAppClientRasdbackend
+  CognitoPoolId:
+    Description: The Cognito Pool ID
+    Value: !Ref CognitoPool
+  CognitoClientId:
+   Description: The Cognito Client ID
+   Value: !Ref CognitoAppClientRasdbackend
   # CognitoClientSecretKey:
   #   Description: The Cognito Client Secret Key
   #   Value: !GetAtt CognitoAppClientRasdbackend.ClientSecret
-  # DynamoDBTableAccessRequests:
-  #   Description: The DynamoDB Table for Access Requests
-  #   Value: !Ref DynamoDBTableDataAccessRequests
+  DynamoDBTableAccessRequests:
+   Description: The DynamoDB Table for Access Requests
+   Value: !Ref DynamoDBTableDataAccessRequests
   # DynamoDBTableMetadata:
   #   Description: The DynamoDB Table for Metadata
   #   Value: !Ref DynamoDBTableMetadata

--- a/cicd/rasd-service/pipeline/lint_build_frontend_buildspec.yaml
+++ b/cicd/rasd-service/pipeline/lint_build_frontend_buildspec.yaml
@@ -19,6 +19,7 @@ phases:
     commands:
       - npm run lint
       - npm run prettier-check
+      - npm run test
 
   build:
     commands:

--- a/cicd/rasd-service/pipeline/pipeline.yaml
+++ b/cicd/rasd-service/pipeline/pipeline.yaml
@@ -302,8 +302,7 @@ Resources:
                     { "name":"RASD_SECRETS_NAME", "value":"#{ExportConfigNS.SECRET_KEY_NAME}" },
                     { "name":"AWS_COGNITO_POOL_ID", "value":"#{CloudFormationOutNS.CognitoPoolId}" },
                     { "name":"AWS_COGNITO_CLIENT_ID", "value":"#{CloudFormationOutNS.CognitoClientId}" },
-                    { "name":"AWS_COGNITO_CLIENT_SECRET_KEY", "value":"#{CloudFormationOutNS.CognitoClientSecretKey}" },
-                    { "name":"AWS_DYNAMODB_TABLE_ACCESS_REQUESTS", "value":"#{CloudFormationOutNS.DynamodbTableAccessRequests}" }
+                    { "name":"AWS_DYNAMODB_TABLE_ACCESS_REQUESTS", "value":"#{CloudFormationOutNS.DynamoDBTableAccessRequests}" }
                   ]
               InputArtifacts:
                 - Name: SourceArtifact

--- a/cicd/rasd-service/pipeline/pipeline.yaml
+++ b/cicd/rasd-service/pipeline/pipeline.yaml
@@ -194,6 +194,8 @@ Resources:
                 FilePaths:
                   Includes:
                     - !Sub cicd/${pProductComponent}/**
+                    - backend/**
+                    - frontend/**
             SourceActionName: CheckoutSrc
       Variables:
         - Name: SRC_BRANCH

--- a/cicd/rasd-service/pipeline/pipeline.yaml
+++ b/cicd/rasd-service/pipeline/pipeline.yaml
@@ -144,26 +144,26 @@ Resources:
         Type: CODEPIPELINE
         BuildSpec: !Sub cicd/${pProductComponent}/pipeline/lint_build_frontend_buildspec.yaml
       TimeoutInMinutes: 5
-  # TestBackend:
-  #   Type: AWS::CodeBuild::Project
-  #   Properties:
-  #     Name: !Sub
-  #       - "${pProductName}-${pProductComponent}-test-backend-${ResourceName}"
-  #       - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
-  #     Description: Test the backend code with poe
-  #     ServiceRole:
-  #       Fn::ImportValue:
-  #         Fn::Sub: ${pBootstrapStackName}-CodeBuildServiceRoleArn
-  #     Artifacts:
-  #       Type: CODEPIPELINE
-  #     Environment:
-  #       Type: LINUX_CONTAINER
-  #       ComputeType: BUILD_GENERAL1_SMALL
-  #       Image: aws/codebuild/standard:7.0
-  #     Source:
-  #       Type: CODEPIPELINE
-  #       BuildSpec: !Sub cicd/${pProductComponent}/pipeline/test_backend_buildspec.yaml
-  #     TimeoutInMinutes: 5
+  TestBackend:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub
+        - "${pProductName}-${pProductComponent}-test-backend-${ResourceName}"
+        - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+      Description: Test the backend code with poe
+      ServiceRole:
+        Fn::ImportValue:
+          Fn::Sub: ${pBootstrapStackName}-CodeBuildServiceRoleArn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:7.0
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: !Sub cicd/${pProductComponent}/pipeline/test_backend_buildspec.yaml
+      TimeoutInMinutes: 5
   ### Pipeline
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
@@ -289,27 +289,27 @@ Resources:
               OutputArtifacts:
                 - Name: BuildFrontendArtifact
               RunOrder: 3
-            # - Name: TestBackend
-            #   ActionTypeId:
-            #     Category: Build
-            #     Owner: AWS
-            #     Provider: CodeBuild
-            #     Version: 1
-            #   Configuration:
-            #     ProjectName: !Ref TestBackend
-            #     EnvironmentVariables: !Sub |
-            #       [
-            #         { "name":"RASD_SECRETS_NAME", "value":"#{ExportConfigNS.SECRET_KEY_NAME}" },
-            #         { "name":"AWS_COGNITO_POOL_ID", "value":"#{CloudFormationOutNS.CognitoPoolId}" },
-            #         { "name":"AWS_COGNITO_CLIENT_ID", "value":"#{CloudFormationOutNS.CognitoClientId}" },
-            #         { "name":"AWS_COGNITO_CLIENT_SECRET_KEY", "value":"#{CloudFormationOutNS.CognitoClientSecretKey}" },
-            #         { "name":"AWS_DYNAMODB_TABLE_ACCESS_REQUESTS", "value":"#{CloudFormationOutNS.DynamodbTableAccessRequests}" }
-            #       ]
-            #   InputArtifacts:
-            #     - Name: SourceArtifact
-            #   OutputArtifacts:
-            #     - Name: TestBackendArtifact
-            #   RunOrder: 4
+            - Name: TestBackend
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: 1
+              Configuration:
+                ProjectName: !Ref TestBackend
+                EnvironmentVariables: !Sub |
+                  [
+                    { "name":"RASD_SECRETS_NAME", "value":"#{ExportConfigNS.SECRET_KEY_NAME}" },
+                    { "name":"AWS_COGNITO_POOL_ID", "value":"#{CloudFormationOutNS.CognitoPoolId}" },
+                    { "name":"AWS_COGNITO_CLIENT_ID", "value":"#{CloudFormationOutNS.CognitoClientId}" },
+                    { "name":"AWS_COGNITO_CLIENT_SECRET_KEY", "value":"#{CloudFormationOutNS.CognitoClientSecretKey}" },
+                    { "name":"AWS_DYNAMODB_TABLE_ACCESS_REQUESTS", "value":"#{CloudFormationOutNS.DynamodbTableAccessRequests}" }
+                  ]
+              InputArtifacts:
+                - Name: SourceArtifact
+              OutputArtifacts:
+                - Name: TestBackendArtifact
+              RunOrder: 4
 
         - Name: Deploy
           Actions:
@@ -424,15 +424,15 @@ Resources:
         - Key: Name
           Value: !Ref AWS::StackName
 
-  # TestBackendLogGroup:
-  #   Type: AWS::Logs::LogGroup
-  #   DeletionPolicy: Delete
-  #   Properties:
-  #     LogGroupName: !Sub /aws/codebuild/${TestBackend}
-  #     RetentionInDays: 30
-  #     Tags:
-  #       - Key: Name
-  #         Value: !Ref AWS::StackName
+  TestBackendLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    Properties:
+      LogGroupName: !Sub /aws/codebuild/${TestBackend}
+      RetentionInDays: 30
+      Tags:
+        - Key: Name
+          Value: !Ref AWS::StackName
 
   EmptyBucketLogGroup:
     Type: AWS::Logs::LogGroup

--- a/cicd/rasd-service/pipeline/pipeline.yaml
+++ b/cicd/rasd-service/pipeline/pipeline.yaml
@@ -301,10 +301,7 @@ Resources:
                 ProjectName: !Ref TestBackend
                 EnvironmentVariables: !Sub |
                   [
-                    { "name":"RASD_SECRETS_NAME", "value":"#{ExportConfigNS.SECRET_KEY_NAME}" },
-                    { "name":"AWS_COGNITO_POOL_ID", "value":"#{CloudFormationOutNS.CognitoPoolId}" },
-                    { "name":"AWS_COGNITO_CLIENT_ID", "value":"#{CloudFormationOutNS.CognitoClientId}" },
-                    { "name":"AWS_DYNAMODB_TABLE_ACCESS_REQUESTS", "value":"#{CloudFormationOutNS.DynamoDBTableAccessRequests}" }
+                    { "name":"RASD_SECRETS_NAME", "value":"#{ExportConfigNS.SECRET_KEY_NAME}" }
                   ]
               InputArtifacts:
                 - Name: SourceArtifact

--- a/cicd/rasd-service/pipeline/test_backend_buildspec.yaml
+++ b/cicd/rasd-service/pipeline/test_backend_buildspec.yaml
@@ -20,8 +20,13 @@ phases:
       - pipx install poethepoet
       - export POETRY_HOME=/root/.local
       - $POETRY_HOME/bin/poetry self add poetry-plugin-export
-      - $POETRY_HOME/bin/poetry install --no-root
+      - $POETRY_HOME/bin/poetry install
+
+  pre_build:
+    commands:
+      - export AWS_COGNITO_CLIENT_SECRET_KEY=$(aws cognito-idp describe-user-pool-client --user-pool-id $AWS_COGNITO_POOL_ID --client-id $AWS_COGNITO_CLIENT_ID --query "UserPoolClient.ClientSecret" --output text)
 
   build:
     commands:
+      - export PATH="$PATH:/root/.local/bin"
       - poe test

--- a/cicd/rasd-service/pipeline/test_backend_buildspec.yaml
+++ b/cicd/rasd-service/pipeline/test_backend_buildspec.yaml
@@ -22,10 +22,6 @@ phases:
       - $POETRY_HOME/bin/poetry self add poetry-plugin-export
       - $POETRY_HOME/bin/poetry install
 
-  pre_build:
-    commands:
-      - export AWS_COGNITO_CLIENT_SECRET_KEY=$(aws cognito-idp describe-user-pool-client --user-pool-id $AWS_COGNITO_POOL_ID --client-id $AWS_COGNITO_CLIENT_ID --query "UserPoolClient.ClientSecret" --output text)
-
   build:
     commands:
       - export PATH="$PATH:/root/.local/bin"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "rasd",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rasd",
+      "devDependencies": {
+        "husky": "^8.0.3"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "rasd",
+  "private": true,
+  "devDependencies": {
+    "husky": "^8.0.3"
+  },
+  "scripts": {
+    "prepare": "husky install"
+  }
+}


### PR DESCRIPTION
A few changes were required to make tests working and passable in codebuild:
- Uncommented codebuild project for testing
- Added pytest Readme file which is required
- Added mock functions to return values for abn responses and mock db responses for functions
- Enable frontend test as well
- I noticed the prettier checks were causing the codebuild failure when not passing as well so instead of waiting for codebuild to fail and tell us, we should be fixing linting errors locally. I have added [husky](https://typicode.github.io/husky/) pre-commit hooks to the project that will warn us of linting errors. Let me know if not suitable.
