### PR TITLE
Make orcID regex less restrictive

### DIFF
--- a/backend/lambdas/rasd_fastapi/types/orcid.py
+++ b/backend/lambdas/rasd_fastapi/types/orcid.py
@@ -14,7 +14,7 @@ class Orcid(str):
     # ORCID Regex
     # See: https://en.wikipedia.org/wiki/ORCID
     # See: https://www.wikidata.org/wiki/Property:P496
-    ORCID_PATTERN = r"^0000-000(1-[5-9]|2-[0-9]|3-[0-4])\d{3}-\d{3}[\dX]$"
+    ORCID_PATTERN = r"^(?:\d{4}-){3}\d{3}[0-9X]$"
     ORCID_REGEX = re.compile(ORCID_PATTERN)
 
     # ORCID Rules

--- a/frontend/src/views/DataAccessRequest.vue
+++ b/frontend/src/views/DataAccessRequest.vue
@@ -52,7 +52,7 @@
           type="input"
           label="OrcID"
           :disabled="!!readOnlyFields"
-          placeholder="e.g. 1111-12345-1111-1111" />
+          placeholder="e.g. 1111-1111-1111-1111" />
         <h2 class="is-size-3 mt-6">Project</h2>
         <validated-field
           v-model:value="projectTitle"


### PR DESCRIPTION
#151 
- Update placeholder to 16 digits
- Update regex to allow 16 digits
- Last digit of orcID can also be an 'X' according to [docs](https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier)